### PR TITLE
Added option to weakly depend on undolr and undoex libraries

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -1,0 +1,18 @@
+/** @file */
+
+#pragma once
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef USE_WEAK_SYMBOLS
+#define __WEAK_SYMBOL__
+#else
+#define __WEAK_SYMBOL__ __attribute__((weak))
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module go.undo.io/bindings
+
+go 1.14

--- a/undoex/undoex-annotations.h
+++ b/undoex/undoex-annotations.h
@@ -1,0 +1,129 @@
+/* Copyright (C) 2016 Undo Ltd. */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../common/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Annotations are a way to programmatically insert data at the current
+ * point in execution in the recording.
+ * Later, the user can analyse the annotations and jump to the point in
+ * execution where they were made.
+ *
+ * Annotations are identified by a name and an optional detail.
+ *
+ * Names starting with "u-" are reserved for internal use.
+ *
+ * The detail is useful to distinguish between different, but related,
+ * annotations with the same name.
+ * For instance, a test could insert an annotation (with its name as name)
+ * when it starts and another one when it ends. The details can mark the
+ * beginning of the test and the end of the test.
+ *
+ * Note that a NULL detail is considered equivalent to a detail identified
+ * by the empty string.
+ *
+ * Each annotation may be associated with some content. The content can be
+ * arbitrary binary data or other predefined types. If a predefined type
+ * matches your content type, it's better to use the predefined type instead of
+ * just storing the content as binary data. For instance, if you are storing
+ * some JSON, use undoex_annotation_add_text() with
+ * `undoex_annotation_content_type_JSON`, if you need to store an int use
+ * undoex_annotation_add_int(). This allows the debugger to present the data
+ * more appropriately.
+ */
+
+/**
+ * \brief The type of text data stored in a recording.
+ *
+ * See undoex_annotation_add_text() for details on the usage.
+ */
+typedef enum
+{
+    undoex_annotation_content_type_JSON              = 101, /**< JSON text */
+    undoex_annotation_content_type_XML               = 102, /**< XML text */
+    undoex_annotation_content_type_UNSTRUCTURED_TEXT = 100, /**< Plain text not matching any other format */
+} undoex_annotation_content_type_t;
+
+/**
+ * \brief Add an annotation (which stores `raw_data` if not NULL) at the
+ * current execution point.
+ *
+ * The stored data can contain any sequence of bytes (including the zero byte).
+ *
+ * If your data is textual add undoex_annotation_add_text() instead. If it's
+ * numeric use undoex_annotation_add_int().
+ *
+ * \param name the name of the annotation
+ * \param detail an optional string specifying extra information about this
+ *        specific annotation (or NULL)
+ * \param raw_data the data to store in the recording or NULL to store the
+ *        annotation without any associated data
+ * \param raw_data_len the length (in bytes) of the `raw_data` buffer;
+ *        ignored if `raw_data` is null
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_annotation_add_raw_data(const char *name,
+                               const char *detail,
+                               const uint8_t *raw_data,
+                               size_t raw_data_len);
+
+/**
+ * \brief Add an annotation (which stores `text` if not null) at the current
+ * execution point.
+ *
+ * The stored data is a string terminated by a zero byte. If you need to store
+ * arbitrary data including null characters, use
+ * undoex_annotation_add_raw_data() instead.
+ *
+ * By specifying the type of the textual content, you allow the debugger to
+ * display the content in a smarter way.
+ *
+ * \param name the name of the annotation
+ * \param detail an optional string specifying extra information about this
+ *        specific annotation (or NULL)
+ * \param content_type the type of the stored textual content
+ * \param text the null-terminated string to store in the recording or NULL
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_annotation_add_text(const char *name,
+                           const char *detail,
+                           undoex_annotation_content_type_t content_type,
+                           const char *text);
+
+/**
+ * \brief Add an annotation (which stores `value`) at the current execution point.
+ *
+ * \param name the name of the annotation
+ * \param detail an optional string specifying extra information about this
+ *        specific annotation (or NULL)
+ * \param value the numeric value to store in the recording
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_annotation_add_int(const char *name,
+                          const char *detail,
+                          int64_t value);
+
+#ifdef __cplusplus
+}
+#endif

--- a/undoex/undoex-test-annotations.go
+++ b/undoex/undoex-test-annotations.go
@@ -7,11 +7,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 package undoex
 
-// -build linux
-
-// #cgo linux,amd64 LDFLAGS: -l undoex_x64
-// #cgo linux,386 LDFLAGS: -l undoex_x32
-// #cgo linux,arm64 LDFLAGS: -l undoex_arm64
 // #include <undoex-test-annotations.h>
 // #include <stdlib.h>
 // #include <errno.h>

--- a/undoex/undoex-test-annotations.h
+++ b/undoex/undoex-test-annotations.h
@@ -1,0 +1,223 @@
+/* Copyright (C) 2016 Undo Ltd. */
+
+#pragma once
+
+#include "../common/common.h"
+
+#include "./undoex-annotations.h"
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief The result of a test.
+ */
+typedef enum
+{
+    /* Keep in sync with the values used in the debugger. */
+    undoex_test_result_UNKNOWN, /**< The result is not known, maybe an error occurred */
+    undoex_test_result_SUCCESS, /**< The test passed */
+    undoex_test_result_FAILURE, /**< The test failed */
+    undoex_test_result_SKIPPED, /**< The test was skipped */
+    undoex_test_result_OTHER,   /**< The test result cannot be represented with this enumeration */
+} undoex_test_result_t;
+
+/**
+ * \brief An object to keep track of a test run through annotations.
+ *
+ * To use, first allocate the test annotation object with
+ * undoex_test_annotation_new(). Update the object using the functions
+ * from this interface, for example undoex_test_annotation_start() to
+ * set the start of the annotation. When you are done and don't need
+ * the object any more, free it with undoex_test_annotation_free().
+ */
+typedef struct _undoex_test_annotation_t undoex_test_annotation_t;
+
+/**
+ * \brief Create an annotation for a test that can be stored in the
+ * recording.
+ *
+ * The returned annotation allows details of a test run to be
+ * programmatically inserted in the recording.
+ *
+ * In case your program makes it possible to execute the same test twice
+ * during a single execution of the program, you can pass true as
+ * `add_run_suffix` to help disambiguate between different runs of the
+ * same test.
+ *
+ * \param base_test_name the name of the test being run
+ * \param add_run_suffix if true, a suffix is added to the test_name to
+ *        differentiate different runs.
+ * \return a newly allocated `undoex_test_annotation_t` in case of success,
+ *         NULL otherwise (and errno will be set accordingly)
+ */
+undoex_test_annotation_t *
+__WEAK_SYMBOL__
+undoex_test_annotation_new(const char *base_test_name,
+                           bool add_run_suffix);
+
+/**
+ * \brief Free an `undoex_test_annotation_t` previously allocated with
+ *        undoex_test_annotation_new().
+ *
+ * \param test_annotation the test annotation to free
+ */
+void
+__WEAK_SYMBOL__
+undoex_test_annotation_free(undoex_test_annotation_t *test_annotation);
+
+/**
+ * \brief Store an annotation for the start of the test execution.
+ *
+ * This is stored in the recording as an annotation with the test name as
+ * annotation name and "u-test-start" as detail. No data is associated
+ * with the annotation.
+ *
+ * \param test_annotation a test annotation
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_start(undoex_test_annotation_t *test_annotation);
+
+/**
+ * \brief Store an annotation for the end of the test execution.
+ *
+ * This is stored in the recording as an annotation with the test name as
+ * annotation name and "u-test-end" as detail. No data is associated
+ * with the annotation.
+ *
+ * This function should be called as soon as the test can be considered
+ * terminated, even if the test result, output or other information are
+ * not available yet.
+ * It's possible to call any of the other functions operating on
+ * `undoex_test_annotation_t` after the test is marked as finished.
+ *
+ * \param test_annotation a test annotation
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_end(undoex_test_annotation_t *test_annotation);
+
+/**
+ * \brief Store whether the test passed or not as an annotation in the recording.
+ *
+ * This is stored in the recording as an annotation with the test name as
+ * annotation name and "u-test-result" as detail. The result is stored as its
+ * data.
+ *
+ * You can call this function at any point after calling
+ * undoex_test_annotation_start(), including before or after calling
+ * undoex_test_annotation_end().
+ *
+ * \param test_annotation a test annotation
+ * \param test_result a `undoex_test_result_t` indicating whether the test
+ *        pass, failed, was skipped, etc.
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_set_result(undoex_test_annotation_t *test_annotation,
+                                  undoex_test_result_t test_result);
+
+/**
+ * \brief Store the textual output of the test.
+ *
+ * This is stored in the recording as an annotation with the test name as
+ * annotation name and "u-test-output" as detail. The result is stored as
+ * its data.
+ *
+ * \param test_annotation a test annotation
+ * \param content_type the type of the stored textual output
+ * \param output the null-terminated string to store in the recording
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_set_output(undoex_test_annotation_t *test_annotation,
+                                  undoex_annotation_content_type_t content_type,
+                                  const char *output);
+
+/**
+ * \brief Add an annotation (which stores `raw_data` if not NULL) at the
+ * current execution point.
+ *
+ * See undoex_annotation_add_raw_data() for extra details.
+ *
+ * \param test_annotation a test annotation
+ * \param detail a string specifying extra information about the annotation;
+ *        this cannot be NULL (otherwise there would be no way of
+ *        distinguishing different events for this test).
+ * \param raw_data the data to store in the recording or NULL to store the
+ *        annotation without any associated data
+ * \param raw_data_len the length (in bytes) of the `raw_data` buffer;
+ *        ignored if `raw_data` is null
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_add_raw_data(undoex_test_annotation_t *test_annotation,
+                                    const char *detail,
+                                    const uint8_t *raw_data,
+                                    size_t raw_data_len);
+
+/**
+ * \brief Add an annotation (which stores `text` if not null) at the current
+ * execution point.
+ *
+ * See undoex_annotation_add_text() for extra details.
+ *
+ * \param test_annotation a test annotation
+ * \param detail a string specifying extra information about the annotation;
+ *        this cannot be NULL (otherwise there would be no way of
+ *        distinguishing different events for this test).
+ * \param content_type the type of the stored textual content
+ * \param text the null-terminated string to store in the recording or NULL
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_add_text(undoex_test_annotation_t *test_annotation,
+                                const char *detail,
+                                undoex_annotation_content_type_t content_type,
+                                const char *text);
+
+/**
+ * \brief Add an annotation (which stores `value`) at the current execution point.
+ *
+ * See undoex_annotation_add_int() for extra details.
+ *
+ * \param test_annotation a test annotation
+ * \param detail a string specifying extra information about the annotation;
+ *        this cannot be NULL (otherwise there would be no way of
+ *        distinguishing different events for this test).
+ * \param value the numeric value to store in the recording
+ * \return 0 in case of success. Otherwise, -1 and `errno` will be set accordingly.
+ *         In particular, if this function is called while not recording, `errno` is set to
+ *         `ENOTSUP`.
+ */
+int
+__WEAK_SYMBOL__
+undoex_test_annotation_add_int(undoex_test_annotation_t *test_annotation,
+                               const char *detail,
+                               int64_t value);
+
+#ifdef __cplusplus
+}
+#endif

--- a/undoex/undoex.go
+++ b/undoex/undoex.go
@@ -7,11 +7,6 @@ SPDX-License-Identifier: BSD-3-Clause
 
 package undoex
 
-// -build linux
-
-// #cgo linux,amd64 LDFLAGS: -l undoex_x64
-// #cgo linux,386 LDFLAGS: -l undoex_x32
-// #cgo linux,arm64 LDFLAGS: -l undoex_arm64
 // #include <undoex-annotations.h>
 // #include <stdlib.h>
 // #include <errno.h>

--- a/undolr/undolr.go
+++ b/undolr/undolr.go
@@ -11,11 +11,6 @@ SPDX-License-Identifier: BSD-3-Clause
 // which can then be opened using the Undo Debugger (UndoDB).
 package undolr
 
-// -build linux
-
-// #cgo linux,amd64 LDFLAGS: -l undolr_x64
-// #cgo linux,386 LDFLAGS: -l undolr_x32
-// #cgo linux,arm64 LDFLAGS: -l undolr_arm64
 // #include <undolr.h>
 // #include <stdlib.h>
 // #include <errno.h>

--- a/undolr/undolr.h
+++ b/undolr/undolr.h
@@ -1,0 +1,362 @@
+/** @file */
+
+/* Copyright (C) 2020 Undo Ltd. */
+
+#ifndef UNDOLR_H
+#define UNDOLR_H
+
+#include "../common/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * API for the Undo Live Recorder.
+ *
+ * Allows an application to create a LiveRecorder recording of itself running, which can
+ * then be loaded in UDB.
+ *
+ * Except where documented, functions in this API return 0 in case of success,
+ * or -1 in case of failure, with an appropriate error code in \c errno.
+ *
+ * Calling undolr_*() functions concurrently from different threads is not
+ * supported, and will give undefined behaviour.
+ *
+ * Please also note that if the application calls undolr_*() functions in one
+ * thread while another thread is waiting for child process by calling
+ * waitpid(-1,&status,__WALL), the application may hang.  The issue arises because
+ * Live Recorder needs to create and wait for a short-lived child process. This
+ * child process is created as a 'clone' process so that it will only be visible
+ * if the __WALL flag is specified.
+ */
+
+/**
+ * \brief Recording context.
+ *
+ * This type serves as a handle for a recorded session whilst it is still in
+ * memory, valid between matched calls to undolr_stop() and undolr_discard().
+ */
+typedef struct undolr_recording_context_private_t *undolr_recording_context_t;
+
+/**
+ * \brief Reason for failing to start recording.
+ *
+ * See undolr_start() and undolr_error_string().
+ */
+typedef enum
+{
+    undolr_error_NONE = 0,
+
+    undolr_error_NO_ATTACH_YAMA = 1,
+    /**< Failure to start-up due to failure to attach to the application process
+    due to /proc/sys/kernel/yama/ptrace_scope. */
+
+    undolr_error_CANNOT_ATTACH = 2,
+
+    undolr_error_LIBRARY_SEARCH_FAILED = 3,
+    /**< Failed to find dynamic libraries used by application. */
+
+    undolr_error_CANNOT_RECORD = 4,
+    /**< Miscellaneous errors without specific error codes. */
+
+    undolr_error_NO_THREAD_INFO = 5,
+    /**< Live Recorder was unable to find information about threads. */
+
+    undolr_error_PKEYS_IN_USE = 6
+    /**< Use of Protection Keys was detected. This is not yet supported. */
+} undolr_error_t;
+
+/**
+ * \brief Return string describing error number.
+ *
+ * \param[in] error Error number from a call to undolr_start().
+ *
+ * \return String describing the error, or "<unknown error>".
+ */
+const char * __WEAK_SYMBOL__ undolr_error_string(undolr_error_t error);
+
+/**
+ * \brief Start recording the current process.
+ *
+ * The current process must not already be being recorded: that is, either
+ * undolr_start() is being called for the first time, or else there was a call
+ * to undolr_stop() since the most recent call to undolr_start().
+ *
+ * \param error [out] pointer to a location to store the reason for
+ *        failure to start recording, or \c NULL not to receive this.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ *
+ * The caller must check the return value to determine if the call succeeded or
+ * failed. If it failed, there may be more specific information about the
+ * failure in \c *error.
+ */
+int __WEAK_SYMBOL__ undolr_start(undolr_error_t *error);
+
+/**
+ * \brief Get the version string for this release.
+ */
+const char * __WEAK_SYMBOL__ undolr_get_version_string(void);
+
+/**
+ * \brief Stop recording the current process.
+ *
+ * \param context [in] pointer to a location to store the recording context, or
+ *        \c NULL if the recording context should be immediately discarded.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ *
+ * If not discarded immediately, the recorded history is held in memory until
+ * \c context is passed to undolr_discard().
+ */
+int __WEAK_SYMBOL__ undolr_stop(undolr_recording_context_t *context);
+
+/**
+ * \brief Save recorded program history to a named recording file.
+ *
+ * The current process must be being recorded: that is, undolr_start() must
+ * have been successfully invoked without a subsequent call to undolr_stop().
+ *
+ * \param filename [in] name of the recording file.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ *
+ * undolr_save() may be called any number of times until undolr_stop() is
+ * called. Each subsequent call to undolr_save() contains later execution
+ * history. The recordings are independent of each other, and each can be
+ * replayed on its own.
+ */
+int __WEAK_SYMBOL__ undolr_save(const char *filename);
+
+/**
+ * \brief Start asynchronously saving recorded program history to a named
+ *        recording file.
+ *
+ * \param context [in] recording context returned by a previous call to
+ *        undolr_stop().
+ *
+ * \param filename [in] name of the recording file.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ *
+ * After this call, the recording context may be passed to
+ * undolr_poll_saving_progress(), but must not be passed to undolr_discard() or
+ * to another call to undolr_save_async() until the save has completed.
+ */
+int __WEAK_SYMBOL__ undolr_save_async(undolr_recording_context_t context, const char *filename);
+
+/**
+ * \brief Check the status of an asynchronous save operation.
+ *
+ * \param context [in] recording context passed to undolr_save_async().
+ *
+ * \param complete [out] pointer to a location that is updated to zero if the
+ *        save is still in progress, or non-zero if it is complete. It is not
+ *        updated if the status could not be determined.
+ *
+ * \param result [out] pointer to a location that is updated only if the save
+ *        operation is complete. It is set to 0 if the recording was saved
+ *        successfully, or to an appropriate error code if it was not. It is
+ *        not updated if \c *complete is zero or if the status could not be
+ *        determined.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_poll_saving_complete(undolr_recording_context_t context,
+                                int *complete, int *result);
+
+/**
+ * \brief Check the status and progress of an asynchronous save operation.
+ *
+ * \param context [in] recording context passed to undolr_save_async().
+ *
+ * \param complete [out] pointer to a location that is updated to zero if the
+ *        save is still in progress, or non-zero if it is complete. It is not
+ *        updated if the status could not be determined.
+ *
+ * \param progress [out] pointer to a location that is updated only if the save
+ *        is still in progress. It is set to the percentage of completion,
+ *        rounded down, from 0 to 100 inclusive, or to -1 if progress
+ *        information is unavailable. It is not updated if \c *complete is
+ *        non-zero or if the status could not be determined.
+ *
+ * \param result [out] pointer to a location that is updated only if the save
+ *        operation is complete. It is set to 0 if the recording was saved
+ *        successfully, or to an appropriate error code if it was not. It is
+ *        not updated if \c *complete is zero or if the status could not be
+ *        determined.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_poll_saving_progress(undolr_recording_context_t context,
+                                int *complete, int *progress, int *result);
+
+/**
+ * \brief Get a selectable file descriptor to detect save state changes.
+ *
+ * \param context [in] recording context passed to undolr_save_async().
+ *
+ * \param fd [out] pointer to a location to store a file descriptor.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ *
+ * When the asynchronous save operation is complete, a byte is written to the
+ * file descriptor, allowing it to be selected for read using select() or
+ * pselect().
+ *
+ * The file descriptor is closed when \c context is passed to undolr_discard().
+ */
+int __WEAK_SYMBOL__ undolr_get_select_descriptor(undolr_recording_context_t context, int *fd);
+
+/**
+ * \brief Discard recorded program history from memory.
+ *
+ * \param context [in] recording context returned by a previous call to
+ *        undolr_stop().
+ *
+ * After calling this, the memory used to maintain the recording state has been
+ * freed, and \c context must not be passed to any other function in this API.
+ */
+int __WEAK_SYMBOL__ undolr_discard(undolr_recording_context_t context);
+
+/**
+ * Instruct LiveRecorder to save a recording when the current process exits.
+ *
+ * LiveRecorder must have been started by a successful call to undolr_start()
+ * before calling this function.
+ *
+ * \param filename [in] the name of the recording file.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ *
+ * The instruction is cancelled by a call to
+ * undolr_save_on_termination_cancel() or undolr_stop().
+ */
+int __WEAK_SYMBOL__ undolr_save_on_termination(const char *filename);
+
+/**
+ * \brief Cancel any previous call to undolr_save_on_termination().
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_save_on_termination_cancel(void);
+
+/**
+ * \brief Retrieve the current event log size
+ *
+ * \param bytes current event log size is stored here on success.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_event_log_size_get(long *bytes);
+
+/**
+ * \brief Set the event log size.
+ *
+ * \param bytes new event log size.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_event_log_size_set(long bytes);
+
+/**
+ * \brief Control whether to include symbol files in saved recordings.
+ *
+ * \param include non-zero to include symbol files, zero to skip. Default 1.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_include_symbol_files(int include);
+
+/**
+ * \brief Set the path of the file where to log all shared memory accesses.
+ *
+ * When a shared memory log filename is set, all accesses to shared memory get logged to that
+ * file, which can be written by multiple processes at the same time.
+ * If this function is not called (or called with `NULL` as `filename`), then an external
+ * shared memory log is not used.
+ *
+ * This feature is currently used in the following way:
+ * - A process creates some shared maps.
+ * - It calls undolr_shmem_log_filename_set().
+ * - It forks some children processes which share the shared memory maps.
+ * - All the processes call undolr_start() to record themselves.
+ * When the processes terminate, loading one of their recordings in UDB will also load the
+ * shared memory access log. Use the `ublame` command to track cross-process accesses to an
+ * address in shared memory.
+ *
+ * This function must be called before recording starts or it will fail and set `errno` to
+ * `EINVAL`.
+ *
+ * Currently, recording accesses to the same map which is mapped at different addresses in
+ * different processes is not supported.
+ *
+ * A process is allowed to call undolr_start() and undolr_stop() multiple times and log its
+ * accesses to the same shared memory log. All the accesses while recording will be logged to
+ * the same file.
+ * This means that separate independent runs should not use the same shared memory log as
+ * the old log is not discarded for the new run.
+ *
+ * \param   filename    The path to a file to use to log accesses to shared memory, or `NULL`
+ *                      to disable the feature (the default).
+ *                      If a non-null path is used, it must have a `.shmem` extension to
+ *                      allow UDB to later find the file. If it doesn't, this function will
+ *                      fail and set `errno` to `EINVAL`.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_shmem_log_filename_set(const char *filename);
+
+/**
+ * \brief Get the current path for the shared memory access log.
+ *
+ * See undolr_shmem_log_filename_set() for details.
+ *
+ * \param[out]  o_filename  A pointer to set to the currently set shared memory log, which can
+ *                          be `NULL` if this feature is not enabled.
+ *                          The string is valid until the next call to
+ *                          undolr_shmem_log_filename_set().
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_shmem_log_filename_get(const char **o_filename);
+
+/**
+ * \brief Set the maximum size of the the file where shared memory accesses are logged.
+ *
+ * See undolr_shmem_log_filename_get() for details about the shared memory log.
+ *
+ * If this function is not called or called with `0` as argument, then a suitable default
+ * value will be used.
+ *
+ * This function must be called before recording starts or it will fail and set `errno` to
+ * `EINVAL`.
+ *
+ * \param   max_size    The maximum size (in bytes) for the shared memory log file.
+ *                      If this is not a multiple of the page size, the actual size can be
+ *                      rounded up to the next multiple.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_shmem_log_size_set(unsigned long max_size);
+
+/**
+ * \brief Get the current maximum size for the shared memory access log.
+ *
+ * See undolr_shmem_log_size_set() for details.
+ *
+ * \param[out]  o_max_size  A pointer to set to the currently set maximum shared memory log
+ *                          size.
+ *
+ * \return 0 for success, or -1 for failure, with an error code in \c errno.
+ */
+int __WEAK_SYMBOL__ undolr_shmem_log_size_get(unsigned long *o_max_size);
+
+#include "./undolr_deprecated.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/undolr/undolr_deprecated.h
+++ b/undolr/undolr_deprecated.h
@@ -1,0 +1,56 @@
+/** @file */
+
+/* Copyright (C) 2017-2018 Undo Ltd. */
+
+#ifndef UNDOLR_DEPRECATED_H
+#define UNDOLR_DEPRECATED_H
+
+#include "../common/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Deprecated components of the Undo Live Recorder API.
+ *
+ * Unless otherwise stated, it is intended that there is an equivalent way
+ * to achieve all functionality offered by functions within this header file.
+ * As such, these functions are intended to be removed in later releases of
+ * Undo Live Recorder.
+ *
+ * If you rely on behaviour that cannot obviously be fulfilled by the contents
+ * of undolr.h, please contact support@undo.io for clarification.
+ */
+
+/**
+ * \deprecated Deprecated alternative to undolr_start().
+ *
+ * Behaves identically to undolr_start() except that if recording is already in
+ * operation, undolr_recording_start() returns zero (indicating success),
+ * whereas undolr_start() returns -1 (indicating failure).
+ */
+int __WEAK_SYMBOL__ undolr_recording_start(undolr_error_t* o_error);
+
+/**
+ * \deprecated Deprecated alternative to undolr_stop().
+ *
+ * Behaves identically to `undolr_stop(NULL)`, so that it stops recording and
+ * discards the recording context without saving.
+ */
+int __WEAK_SYMBOL__ undolr_recording_stop(void);
+
+/**
+ * \deprecated Deprecated alternative to undolr_stop() followed by
+ * undolr_save_async().
+ *
+ * Stops recording, saves asynchronously to `filename`, and detaches from the
+ * debuggee so that recording cannot be restarted.
+ */
+int __WEAK_SYMBOL__ undolr_recording_stop_and_save(const char* filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Use CGO_CFLAGS="-DUSE_WEAK_SYMBOLS" to build binaries with weak symbols.

The header files have been copied from undodb-6.3.3.19

Side effect:
* Build: Linker flags (CGO_LDFLAGS) to link to the libraries (-l<lib>)
  will also need to be provided at build time.
* Test: Linker flags (-l<lib>) and path to the libraries (LD_LIBRARY_PATH)
  will need to be provided to the loader.